### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# MySQL Database Access MCP Server
+<a href="https://glama.ai/mcp/servers/@dpflucas/mysql-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dpflucas/mysql-mcp-server/badge" alt="mysql-mcp-server MCP server" />
+</a>
+
 [![smithery badge](https://smithery.ai/badge/@dpflucas/mysql-mcp-server)](https://smithery.ai/server/@dpflucas/mysql-mcp-server)
+
+# MySQL Database Access MCP Server
 
 This MCP server provides read-only access to MySQL databases. It allows you to:
 


### PR DESCRIPTION
This PR adds a badge for the [mysql-mcp-server](https://glama.ai/mcp/servers/@dpflucas/mysql-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@dpflucas/mysql-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dpflucas/mysql-mcp-server/badge" alt="mysql-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.