### PR TITLE
Improve Disallowed Commands

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -35,6 +35,9 @@ const DISALLOWED_COMMANDS = [
   'BEGIN',
   'COMMIT',
   'ROLLBACK',
+  'OUTFILE',
+  'DUMPFILE',
+  'LOAD_FILE'
 ];
 
 /**


### PR DESCRIPTION
SELECT INTO OUTFILE and SELECT INTO DUMPFILE allow writing files, which contradicts the read-only restriction. Further, LOAD_FILE is often overlooked and might allow to read arbitrary files if the MySQL Server is poorly configured.